### PR TITLE
Fixes #32 by inhibiting fast clicks to many tabs

### DIFF
--- a/lib/BottomNavigation.js
+++ b/lib/BottomNavigation.js
@@ -65,6 +65,7 @@ export default class BottomNavigation extends Component {
 
     // Default values
     this.layoutWillChange = false
+    this.lastTabChangeDate = -1
     this.dimensions = { width: -1, height: -1 }
     this.nextActiveTab = props.activeTab
     this.state = {
@@ -140,7 +141,6 @@ export default class BottomNavigation extends Component {
       }
     }
   }
-
   render() {
     const {
       backgroundColor,
@@ -197,8 +197,23 @@ export default class BottomNavigation extends Component {
       </View>
     )
   }
+  _canChangeTabs() {
+    //Ignore tab taps that are < .5 seconds apart
+    const TAB_BLOCK_DELAY_SECONDS = .5;
+    if (this.lastTabChangeDate < 0) {
+      return true
+    }
+
+    return (new Date() - this.lastTabChangeDate) > TAB_BLOCK_DELAY_SECONDS * 1000
+  }
 
   _handleTabChange = ({ tabIndex, barBackgroundColor }) => {
+    if (this.nextActiveTab === this.activeTab || !this._canChangeTabs()) {
+      //Block repetitive or super fast tab switches. Fixes Issue #32.
+      return;
+    } else {
+      this.lastTabChangeDate = new Date();
+    }
     const { x, y } = this.iconPositions[tabIndex]
 
     // Directly save the active tab index, but not in the state.


### PR DESCRIPTION
See https://github.com/timomeh/react-native-material-bottom-navigation/issues/32.

Clicking tabs fast makes them get into an infinite loop of switching. Easiest to repro on a real device.  This just enforces a 1/2 sec time window before tabs can be switched again.