### PR TITLE
fix shifting can't set to false

### DIFF
--- a/lib/BottomNavigation.js
+++ b/lib/BottomNavigation.js
@@ -150,7 +150,7 @@ export default class BottomNavigation extends Component {
       activeTab
     } = this.state
 
-    var shifting = this.props.shifting != null
+    var shifting = this.props.shifting !== null
       ? this.props.shifting
       : this.props.children.length > 3
 


### PR DESCRIPTION
When I set shifting props to false it doesn’t take effect. The tabs are still shifting.
