### PR TITLE
Fix For React Navigation Beta 20+

### DIFF
--- a/lib/NavigationComponent.js
+++ b/lib/NavigationComponent.js
@@ -58,6 +58,7 @@ class NavigationComponent extends PureComponent<void, NCProps, void> {
       backgroundColor: bnOptions.backgroundColor,
       shifting: bnOptions.shifting
     }
+    const previousScene = navigationState.routes[navigationState.index]
 
     return (
       <BottomNavigation
@@ -80,7 +81,7 @@ class NavigationComponent extends PureComponent<void, NCProps, void> {
             focused,
             tintColor: focused ? activeTintColor : inactiveTintColor
           }
-          const onPress = navigationGetOnPress(scene)
+          const onPress = navigationGetOnPress(previousScene, scene)
           const label = getLabel(scene)
           const icon = renderIcon(scene)
 


### PR DESCRIPTION
This seems to fix the [issue](https://github.com/timomeh/react-native-material-bottom-navigation/issues/61) people are having with React Navigation Beta.20+. Just need to pass in `previousScene`.