### PR TITLE
Update default Tab index

### DIFF
--- a/lib/TabList.js
+++ b/lib/TabList.js
@@ -42,7 +42,8 @@ export default class TabList extends React.PureComponent {
 
   constructor(props) {
     super(props)
-
+    // Default tab index is in the middle
+    let defaultTabIndex = Math.floor(props.tabs.length / 2)
     // When the user presses a Tab, the Decorator data is stored in here and
     // retrieved when the Tab visually becomes active.
     // We need to temporarily store it for the controlled component because we
@@ -53,7 +54,7 @@ export default class TabList extends React.PureComponent {
     this.isControlled = props.activeTab != null
 
     this.state = {
-      activeTab: this.isControlled ? props.activeTab : props.tabs[0].key
+      activeTab: this.isControlled ? props.activeTab : props.tabs[defaultTabIndex].key
     }
   }
 

--- a/lib/TabList.js
+++ b/lib/TabList.js
@@ -42,8 +42,6 @@ export default class TabList extends React.PureComponent {
 
   constructor(props) {
     super(props)
-    // expect defaultTabIndex otherwise default should be first index
-    let defaultTabIndex = props.defaultTabIndex || 0
     // When the user presses a Tab, the Decorator data is stored in here and
     // retrieved when the Tab visually becomes active.
     // We need to temporarily store it for the controlled component because we
@@ -54,7 +52,7 @@ export default class TabList extends React.PureComponent {
     this.isControlled = props.activeTab != null
 
     this.state = {
-      activeTab: this.isControlled ? props.activeTab : props.tabs[defaultTabIndex].key
+      activeTab: this.isControlled ? props.activeTab : props.tabs[props.defaultTabIndex || 0].key
     }
   }
 

--- a/lib/TabList.js
+++ b/lib/TabList.js
@@ -42,8 +42,8 @@ export default class TabList extends React.PureComponent {
 
   constructor(props) {
     super(props)
-    // Default tab index is in the middle
-    let defaultTabIndex = Math.floor(props.tabs.length / 2)
+    // expect defaultTabIndex otherwise default should be first index
+    let defaultTabIndex = props.defaultTabIndex || 0
     // When the user presses a Tab, the Decorator data is stored in here and
     // retrieved when the Tab visually becomes active.
     // We need to temporarily store it for the controlled component because we


### PR DESCRIPTION
I have many routes 
[likes, search, home, profile, settings]
and suggest making the default  route to be in the middle,
or we can add defaultTab prop into tabs property which should be the default
regards