### PR TITLE
Fix Typescript UMD global error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import React from 'react'
 import { ViewStyle, TextStyle, StyleProp, Animated } from 'react-native'
 
 declare module 'react-native-material-bottom-navigation' {


### PR DESCRIPTION
When trying to use this package with newer versions of typescript an error is generated (see below)
This PR adds the missing import which resolves the problem!

```
node_modules/react-native-material-bottom-navigation/index.d.ts:58:49 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

58   export default class BottomNavigation extends React.Component<
                                                   ~~~~~

node_modules/react-native-material-bottom-navigation/index.d.ts:61:32 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

61   export class IconTab extends React.Component<IconTabProps> {}
                                  ~~~~~

node_modules/react-native-material-bottom-navigation/index.d.ts:62:32 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

62   export class FullTab extends React.Component<FullTabProps> {}
                                  ~~~~~

node_modules/react-native-material-bottom-navigation/index.d.ts:63:36 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

63   export class ShiftingTab extends React.Component<FullTabProps> {}
                                      ~~~~~

node_modules/react-native-material-bottom-navigation/index.d.ts:64:30 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

64   export class Badge extends React.Component<BadgeProps> {}

```